### PR TITLE
Fixing Lit Geom SinglePassInstanced and shadows

### DIFF
--- a/Assets/Fur/Shaders/Geometry/Lit.hlsl
+++ b/Assets/Fur/Shaders/Geometry/Lit.hlsl
@@ -6,6 +6,7 @@
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 #include "./Param.hlsl"
 #include "../Common/Common.hlsl"
+#include "HLSLSupport.cginc"
 
 struct _Attributes
 {
@@ -14,6 +15,7 @@ struct _Attributes
     float2 texcoord : TEXCOORD0;
     float2 lightmapUV : TEXCOORD1;
     uint id : SV_VertexID;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
 struct Attributes
@@ -23,6 +25,8 @@ struct Attributes
     float2 texcoord : TEXCOORD0;
     float2 lightmapUV : TEXCOORD1;
     uint id : TEXCOORD2;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+    UNITY_VERTEX_OUTPUT_STEREO
 };
 
 struct Varyings
@@ -34,19 +38,31 @@ struct Varyings
     DECLARE_LIGHTMAP_OR_SH(lightmapUV, vertexSH, 4);
     float4 fogFactorAndVertexLight : TEXCOORD5; // x: fogFactor, yzw: vertex light
     float factor : TEXCOORD6;
+    UNITY_VERTEX_OUTPUT_STEREO
 };
 
 Attributes vert(_Attributes input)
 {
+    Attributes output;
+    UNITY_INITIALIZE_OUTPUT(Attributes, output);
+    //UNITY_SETUP_INSTANCE_ID(input); //Insert
+    //UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output); //Insert
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
     FurMoverData data = _Buffer[input.id];
+    //UNITY_INITIALIZE_OUTPUT(Attributes, output); //Insert
+    output.positionOS = input.positionOS;
+    output.normalOS = input.normalOS;
+    output.texcoord = input.texcoord;
+    output.lightmapUV = input.lightmapUV;
+    output.id = input.id;
 
     float time = _Time.y;
     if (abs(time - data.time) > 1e-3)
     {
-        float3 targetPosWS = TransformObjectToWorld(input.positionOS.xyz);
+        float3 targetPosWS = TransformObjectToWorld(output.positionOS.xyz);
         float3 dPosWS = targetPosWS - data.posWS;
         float3 forceWS = _Spring * dPosWS - data.velocityWS * _Damper + float3(0.0, _Gravity, 0.0);
-        float3 normalWS = TransformObjectToWorldNormal(input.normalOS, true);
+        float3 normalWS = TransformObjectToWorldNormal(output.normalOS, true);
         float dt = 1.0 / 60;
         data.velocityWS += forceWS * dt;
         data.posWS += data.velocityWS * dt;
@@ -54,10 +70,10 @@ Attributes vert(_Attributes input)
         float move = length(data.dPosWS);
         data.dPosWS = min(move, 1.0) / max(move, 0.01) * data.dPosWS;
         data.time = time;
-        _Buffer[input.id] = data;
+        _Buffer[output.id] = data;
     }
 
-    return (Attributes)input;
+    return output;
 }
 
 void AppendVertex(
@@ -66,9 +82,13 @@ void AppendVertex(
     float3 normalOS, 
     float2 uv, 
     float2 lightmapUV,
-    float factor)
+    float factor,
+    Attributes input0)
 {
-    Varyings output = (Varyings)0;
+    Varyings output;
+    //UNITY_INITIALIZE_OUTPUT(Varyings, output);
+    //UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+    UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(input0, output);
 
     VertexPositionInputs vertexInput = GetVertexPositionInputs(posOS);
     output.positionCS = vertexInput.positionCS;
@@ -90,6 +110,16 @@ void AppendVertex(
 [maxvertexcount(45)]
 void geom(triangle Attributes input[3], inout TriangleStream<Varyings> stream)
 {
+    UNITY_SETUP_INSTANCE_ID(input[0]);
+    //UNITY_SETUP_INSTANCE_ID(input[1]);
+    //UNITY_SETUP_INSTANCE_ID(input[2]);
+    //UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input[0])
+    //UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input[1])
+    //UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input[2])
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(input[0]);
+    //UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(input[1]);
+    //UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(input[2]);
+    //UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
     uint id0 = input[0].id;
     uint id1 = input[1].id;
     uint id2 = input[2].id;
@@ -175,14 +205,14 @@ void geom(triangle Attributes input[3], inout TriangleStream<Varyings> stream)
         float2 nextLightmapUv1 = prevUv1 + lightmapUvInterp1 * delta;
         float2 nextLightmapUv2 = prevUv2 + lightmapUvInterp2 * delta;
 
-        AppendVertex(stream, nextPos0OS, nextNormal0OS, nextUv0, nextLightmapUv0, nextFactor);
-        AppendVertex(stream, prevPos0OS, prevNormal0OS, prevUv0, prevLightmapUv0, prevFactor);
-        AppendVertex(stream, nextPos1OS, nextNormal1OS, nextUv1, nextLightmapUv1, nextFactor);
-        AppendVertex(stream, prevPos1OS, prevNormal1OS, prevUv1, prevLightmapUv1, prevFactor);
-        AppendVertex(stream, nextPos2OS, nextNormal2OS, nextUv2, nextLightmapUv2, nextFactor);
-        AppendVertex(stream, prevPos2OS, prevNormal2OS, prevUv2, prevLightmapUv2, prevFactor);
-        AppendVertex(stream, nextPos0OS, nextNormal0OS, nextUv0, nextLightmapUv0, nextFactor);
-        AppendVertex(stream, prevPos0OS, prevNormal0OS, prevUv0, prevLightmapUv0, prevFactor);
+        AppendVertex(stream, nextPos0OS, nextNormal0OS, nextUv0, nextLightmapUv0, nextFactor, input[0]);
+        AppendVertex(stream, prevPos0OS, prevNormal0OS, prevUv0, prevLightmapUv0, prevFactor, input[0]);
+        AppendVertex(stream, nextPos1OS, nextNormal1OS, nextUv1, nextLightmapUv1, nextFactor, input[0]);
+        AppendVertex(stream, prevPos1OS, prevNormal1OS, prevUv1, prevLightmapUv1, prevFactor, input[0]);
+        AppendVertex(stream, nextPos2OS, nextNormal2OS, nextUv2, nextLightmapUv2, nextFactor, input[0]);
+        AppendVertex(stream, prevPos2OS, prevNormal2OS, prevUv2, prevLightmapUv2, prevFactor, input[0]);
+        AppendVertex(stream, nextPos0OS, nextNormal0OS, nextUv0, nextLightmapUv0, nextFactor, input[0]);
+        AppendVertex(stream, prevPos0OS, prevNormal0OS, prevUv0, prevLightmapUv0, prevFactor, input[0]);
 
         prevFactor = nextFactor;
 
@@ -209,16 +239,18 @@ void geom(triangle Attributes input[3], inout TriangleStream<Varyings> stream)
 
     float3 topNormalOS = SafeNormalize(topMovedPosOS - prevCenterPosOS);
     topNormalOS = SafeNormalize(lerp(faceNormalOS, topNormalOS, _NormalFactor));
-    AppendVertex(stream, prevPos0OS, prevNormal0OS, prevUv0, prevLightmapUv0, prevFactor);
-    AppendVertex(stream, prevPos1OS, prevNormal1OS, prevUv1, prevLightmapUv1, prevFactor);
-    AppendVertex(stream, topMovedPosOS, topNormalOS, topUv, topLightmapUv, 1.0);
-    AppendVertex(stream, prevPos2OS, prevNormal2OS, prevUv2, prevLightmapUv2, prevFactor);
-    AppendVertex(stream, prevPos0OS, prevNormal0OS, prevUv0, prevLightmapUv0, prevFactor);
+    AppendVertex(stream, prevPos0OS, prevNormal0OS, prevUv0, prevLightmapUv0, prevFactor, input[0]);
+    AppendVertex(stream, prevPos1OS, prevNormal1OS, prevUv1, prevLightmapUv1, prevFactor, input[0]);
+    AppendVertex(stream, topMovedPosOS, topNormalOS, topUv, topLightmapUv, 1.0, input[0]);
+    AppendVertex(stream, prevPos2OS, prevNormal2OS, prevUv2, prevLightmapUv2, prevFactor, input[0]);
+    AppendVertex(stream, prevPos0OS, prevNormal0OS, prevUv0, prevLightmapUv0, prevFactor, input[0]);
     stream.RestartStrip();
 }
 
 float4 frag(Varyings input) : SV_Target
 {
+    //UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+    //UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(input, output);
     SurfaceData surfaceData = (SurfaceData)0;
     InitializeStandardLitSurfaceData(input.uv, surfaceData);
     surfaceData.occlusion = lerp(sqrt(abs(1.0 - _Occlusion)), 1.0, input.factor);
@@ -238,12 +270,20 @@ float4 frag(Varyings input) : SV_Target
     inputData.bakedGI = SAMPLE_GI(input.lightmapUV, input.vertexSH, inputData.normalWS);
 
 #if 1
-    float4 color = UniversalFragmentPBR(inputData, surfaceData);
+    /*float4 color = UniversalFragmentPBR(inputData, surfaceData);
     ApplyRimLight(color.rgb, inputData.positionWS, inputData.viewDirectionWS, inputData.normalWS);
     color.rgb += _AmbientColor.rgb;
-    color.rgb = MixFog(color.rgb, inputData.fogCoord);
+    color.rgb = clamp(MixFog(color.rgb, inputData.fogCoord), 0, 1);*/
+
+    Light mainLight = GetMainLight(TransformWorldToShadowCoord(input.positionWS));
+    float shadow = mainLight.distanceAttenuation * mainLight.shadowAttenuation;
+    float4 color = UniversalFragmentPBR(inputData, surfaceData);
+
+    color.rgb *= shadow;
+    //ApplyRimLight(color.rgb, input.positionWS, viewDirWS, normalWS);
+    color.rgb = clamp(color.rgb + _AmbientColor, 0, 1);
 #else
-    float4 color = float4(inputData.normalWS, 1.0);
+    float4 color = clamp(float4(inputData.normalWS, 1.0), 0, 1);
 #endif
 
     return color;

--- a/Assets/Fur/Shaders/Geometry/Lit.shader
+++ b/Assets/Fur/Shaders/Geometry/Lit.shader
@@ -70,6 +70,8 @@ SubShader
         #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
 
         // Unity
+        #pragma multi_compile_instancing
+        #pragma multi_compile _ DOTS_INSTANCING_ON
         #pragma multi_compile _ DIRLIGHTMAP_COMBINED
         #pragma multi_compile _ LIGHTMAP_ON
         #pragma multi_compile_fog
@@ -99,6 +101,8 @@ SubShader
 
         HLSLPROGRAM
         #pragma exclude_renderers gles gles3 glcore
+        #pragma multi_compile_instancing
+        #pragma multi_compile _ DOTS_INSTANCING_ON
         #pragma multi_compile_fog
         #pragma multi_compile _ DRAW_ORIG_POLYGON
         #pragma multi_compile _ APPEND_MORE_FINS
@@ -126,6 +130,8 @@ SubShader
         HLSLPROGRAM
         #pragma exclude_renderers gles gles3 glcore
         #pragma multi_compile_fog
+        #pragma multi_compile_instancing
+        #pragma multi_compile _ DOTS_INSTANCING_ON
         #pragma multi_compile _ DRAW_ORIG_POLYGON
         #pragma multi_compile _ APPEND_MORE_FINS
         #pragma vertex vert
@@ -141,5 +147,4 @@ SubShader
         ENDHLSL
     }
 }
-
 }

--- a/Assets/Fur/Shaders/Geometry/LitTessellation.hlsl
+++ b/Assets/Fur/Shaders/Geometry/LitTessellation.hlsl
@@ -26,6 +26,7 @@ struct HsConstantOutput
 [outputcontrolpoints(3)]
 Attributes hull(InputPatch<Attributes, 3> input, uint id : SV_OutputControlPointID)
 {
+    UNITY_SETUP_INSTANCE_ID(input[id]);
     return input[id];
 }
 
@@ -76,7 +77,9 @@ Attributes domain(
     const OutputPatch<Attributes, 3> i,
     float3 bary : SV_DomainLocation)
 {
-    Attributes o = (Attributes)0;
+    Attributes o;
+    UNITY_INITIALIZE_OUTPUT(Attributes, o);
+    UNITY_TRANSFER_INSTANCE_ID(i[0], o);
 
     float fU = bary.x;
     float fV = bary.y;


### PR DESCRIPTION
Fixing two things:

- unclamped color resulting in a quite brilliant sparkling effect when postprocessing is turned on (see below);
- missing shadows in URP 12.1 (per https://github.com/hecomi/UnityFurURP/issues/4#issuecomment-982723434);

and adding one:

- Single-Pass Instanced VR mode (what I originally set out to do);

in only the Lit Geometry shader. I have no plans to fix the other shaders but they shouldn't be too hard for anyone else to fix as they need, in the spirit of open source. :-) With SPI, due to the lack of documentation on the subject, I ended up taking the advice of someone in a forum somewhere and just turned on MockHMD and prayed and trial-and-errored until it worked. 😆

![unity-fur-sparkle-ezgif-4-0ec1a518c0](https://user-images.githubusercontent.com/314147/162640754-6b8bdba7-da97-4f3d-8543-6887e856bac3.gif)
 