### PR TITLE
Various features added for Shell Lit

### DIFF
--- a/Assets/Fur/Shaders/Shell/Depth.hlsl
+++ b/Assets/Fur/Shaders/Shell/Depth.hlsl
@@ -3,6 +3,8 @@
 
 #include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitInput.hlsl"
 #include "./Param.hlsl"
+// For VR single pass instance compability:
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 
 struct Attributes
 {
@@ -10,29 +12,63 @@ struct Attributes
     float3 normalOS : NORMAL;
     float4 tangentOS : TANGENT;
     float2 uv : TEXCOORD0;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
-struct Varyings
+struct v2g
+{
+    float4 positionOS : POSITION;
+    float3 normalOS : NORMAL;
+    float4 tangentOS : TANGENT;
+    float2 uv : TEXCOORD0;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+};
+
+struct g2f
 {
     float4 vertex : SV_POSITION;
     float2 uv : TEXCOORD0;
     float  fogCoord : TEXCOORD1;
     float  layer : TEXCOORD2;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+    UNITY_VERTEX_OUTPUT_STEREO
 };
 
-Attributes vert(Attributes input)
+v2g vert(Attributes input)
 {
-    return input;
+    v2g output = (v2g)0;
+    // setup the instanced id
+    UNITY_SETUP_INSTANCE_ID(input);
+    // set all values in the "v2g output" to 0.0
+    // This is the URP version of UNITY_INITIALIZE_OUTPUT()
+    ZERO_INITIALIZE(v2g, output);
+    // copy instance id in the "Attributes input" to the "v2g output"
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+
+    output.positionOS = input.positionOS;
+    output.normalOS = input.normalOS;
+    output.tangentOS = input.tangentOS;
+    output.uv = input.uv;
+    return output;
 }
 
-void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, int index)
+void AppendShellVertex(inout TriangleStream<g2f> stream, v2g input, int index)
 {
-    Varyings output = (Varyings)0;
+    g2f output = (g2f)0;
+    UNITY_SETUP_INSTANCE_ID(input);
+    // set all values in the g2f output to 0.0
+    ZERO_INITIALIZE(g2f, output);
+
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
 
     VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
     VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
 
-    float moveFactor = pow(abs((float)index / _ShellAmount), _BaseMove.w);
+    float clampedShellAmount = clamp(_ShellAmount, 1, 13);
+    _ShellStep = _TotalShellStep / clampedShellAmount;
+
+    float moveFactor = pow(abs((float)index / clamp(_ShellAmount, 1, 13)), _BaseMove.w);
     float3 posOS = input.positionOS.xyz;
     float3 windAngle = _Time.w * _WindFreq.xyz;
     float3 windMove = moveFactor * _WindMove.xyz * sin(windAngle + posOS * _WindMove.w);
@@ -46,15 +82,73 @@ void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, 
     output.vertex = posCS;
     output.uv = TRANSFORM_TEX(input.uv, _BaseMap);
     output.fogCoord = ComputeFogFactor(posCS.z);
+    output.layer = (float)index / clamp(_ShellAmount, 1, 13);
+
+    stream.Append(output);
+}
+
+// For geometry shader instancing, no clamp on _ShellAmount.
+void AppendShellVertexInstancing(inout TriangleStream<g2f> stream, v2g input, int index)
+{
+    g2f output = (g2f)0;
+    UNITY_SETUP_INSTANCE_ID(input);
+    // set all values in the g2f output to 0.0
+    ZERO_INITIALIZE(g2f, output);
+
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+    VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
+    VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+
+    _ShellStep = _TotalShellStep / _ShellAmount;
+
+    float moveFactor = pow(abs((float)index / _ShellAmount), _BaseMove.w);
+    float3 posOS = input.positionOS.xyz;
+    float3 windAngle = _Time.w * _WindFreq.xyz;
+    float3 windMove = moveFactor * _WindMove.xyz * sin(windAngle + posOS * _WindMove.w);
+    float3 move = moveFactor * _BaseMove.xyz;
+
+    float3 shellDir = normalize(normalInput.normalWS + move + windMove);
+    float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.uv / _BaseMap_ST.xy, 0).x;
+    float3 posWS = vertexInput.positionWS + shellDir * (_ShellStep * index * FurLength * _FurLengthIntensity);
+    float4 posCS = TransformWorldToHClip(posWS);
+
+    output.vertex = posCS;
+    output.uv = TRANSFORM_TEX(input.uv, _BaseMap);
+    output.fogCoord = ComputeFogFactor(posCS.z);
     output.layer = (float)index / _ShellAmount;
 
     stream.Append(output);
 }
 
-[maxvertexcount(128)]
-void geom(triangle Attributes input[3], inout TriangleStream<Varyings> stream)
+//-----------------------------------(below) For Microsoft Shader Model > 4.1-----------------------------------
+// See "Lit.hlsl" for more information.
+#if defined(_GEOM_INSTANCING)
+[instance(3)]
+[maxvertexcount(39)]
+void geom(triangle v2g input[3], inout TriangleStream<g2f> stream, uint instanceID : SV_GSInstanceID)
 {
-    [loop] for (float i = 0; i < _ShellAmount; ++i)
+    // 13 is calculated manually, because "maxvertexcount" is 39 in "Lit.hlsl", keep all passes to have the smallest (39 now).
+    // If not, DepthNormals will be incorrect and Depth Priming (DepthNormal Mode) won't work.
+    // "39 / 3 = 13", 3 means 3 vertices of a tirangle.
+    [loop] for (float i = 0 + (instanceID * 13); i < _ShellAmount; ++i)
+    {
+        [unroll] for (float j = 0; j < 3; ++j)
+        {
+            AppendShellVertexInstancing(stream, input[j], i);
+        }
+        stream.RestartStrip();
+    }
+}
+//-----------------------------------(above) For Microsoft Shader Model > 4.1-----------------------------------
+
+//-----------------------------------(below) For Microsoft Shader Model < 4.1-----------------------------------
+#else
+[maxvertexcount(39)]
+void geom(triangle v2g input[3], inout TriangleStream<g2f> stream)
+{
+    [loop] for (float i = 0; i < clamp(_ShellAmount, 1, 13); ++i)
     {
         [unroll] for (float j = 0; j < 3; ++j)
         {
@@ -63,10 +157,12 @@ void geom(triangle Attributes input[3], inout TriangleStream<Varyings> stream)
         stream.RestartStrip();
     }
 }
+#endif
+//-----------------------------------(above) For Microsoft Shader Model < 4.1-----------------------------------
 
 // Previous frag() causes Depth Priming error (black pixels),
 // when enabling "Depth Priming + MSAA" in URP 12.1.
-float frag(Varyings input) : SV_TARGET
+float frag(g2f input) : SV_TARGET
 {
     float4 furColor = SAMPLE_TEXTURE2D(_FurMap, sampler_FurMap, input.uv / _BaseMap_ST.xy * _FurScale);
     float alpha = furColor.r * (1.0 - input.layer);

--- a/Assets/Fur/Shaders/Shell/Depth.hlsl
+++ b/Assets/Fur/Shaders/Shell/Depth.hlsl
@@ -39,7 +39,7 @@ void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, 
     float3 move = moveFactor * _BaseMove.xyz;
 
     float3 shellDir = normalize(normalInput.normalWS + move + windMove);
-    float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.uv / _BaseMap_ST.xy * _FurScale, 0).x;
+    float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.uv / _BaseMap_ST.xy, 0).x;
     float3 posWS = vertexInput.positionWS + shellDir * (_ShellStep * index * FurLength * _FurLengthIntensity);
     float4 posCS = TransformWorldToHClip(posWS);
     

--- a/Assets/Fur/Shaders/Shell/DepthNormals.hlsl
+++ b/Assets/Fur/Shaders/Shell/DepthNormals.hlsl
@@ -4,6 +4,8 @@
 #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderVariablesFunctions.hlsl"
 #include "./Param.hlsl"
+// For VR single pass instance compability:
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 
 struct Attributes
 {
@@ -11,9 +13,19 @@ struct Attributes
     half3 normalOS : NORMAL;
     half4 tangentOS : TANGENT;
     float2 uv : TEXCOORD0;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
-struct Varyings
+struct v2g
+{
+    half4 positionOS : POSITION;
+    half3 normalOS : NORMAL;
+    half4 tangentOS : TANGENT;
+    float2 uv : TEXCOORD0;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+};
+
+struct g2f
 {
     float4 vertex : SV_POSITION;
     float2 uv : TEXCOORD0;
@@ -22,19 +34,82 @@ struct Varyings
     float3 normalWS : TEXCOORD2;
     float3 tangentWS : TEXCOORD3;
     float3 posWS : TEXCOORD4;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+    UNITY_VERTEX_OUTPUT_STEREO
 };
 
-Attributes vert(Attributes input)
+v2g vert(Attributes input)
 {
-    return input;
+    v2g output = (v2g)0;
+    // setup the instanced id
+    UNITY_SETUP_INSTANCE_ID(input);
+    // set all values in the "v2g output" to 0.0
+    // This is the URP version of UNITY_INITIALIZE_OUTPUT()
+    ZERO_INITIALIZE(v2g, output);
+    // copy instance id in the "Attributes input" to the "v2g output"
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+
+    output.positionOS = input.positionOS;
+    output.normalOS = input.normalOS;
+    output.tangentOS = input.tangentOS;
+    output.uv = input.uv;
+    return output;
 }
 
-void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, int index)
+void AppendShellVertex(inout TriangleStream<g2f> stream, v2g input, int index)
 {
-    Varyings output = (Varyings)0;
+    g2f output = (g2f)0;
+    UNITY_SETUP_INSTANCE_ID(input);
+    // set all values in the g2f output to 0.0
+    ZERO_INITIALIZE(g2f, output);
+
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
 
     VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
     VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+
+    float clampedShellAmount = clamp(_ShellAmount, 1, 13);
+    _ShellStep = _TotalShellStep / clampedShellAmount;
+
+    float moveFactor = pow(abs((float)index / clamp(_ShellAmount, 1, 13)), _BaseMove.w);
+    float3 posOS = input.positionOS.xyz;
+    float3 windAngle = _Time.w * _WindFreq.xyz;
+    float3 windMove = moveFactor * _WindMove.xyz * sin(windAngle + posOS * _WindMove.w);
+    float3 move = moveFactor * _BaseMove.xyz;
+
+    float3 shellDir = SafeNormalize(normalInput.normalWS + move + windMove);
+    float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.uv / _BaseMap_ST.xy, 0).x;
+    float3 posWS = vertexInput.positionWS + shellDir * (_ShellStep * index * FurLength * _FurLengthIntensity);
+    float4 posCS = TransformWorldToHClip(posWS);
+
+    output.vertex = posCS;
+    output.posWS = posWS;
+    output.uv = TRANSFORM_TEX(input.uv, _BaseMap);
+    output.layer = (float)index / clamp(_ShellAmount, 1, 13);
+
+    output.normalWS = normalInput.normalWS;
+    output.tangentWS = normalInput.tangentWS;
+
+
+    stream.Append(output);
+}
+
+// For geometry shader instancing, no clamp on _ShellAmount.
+void AppendShellVertexInstancing(inout TriangleStream<g2f> stream, v2g input, int index)
+{
+    g2f output = (g2f)0;
+    UNITY_SETUP_INSTANCE_ID(input);
+    // set all values in the g2f output to 0.0
+    ZERO_INITIALIZE(g2f, output);
+
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+    VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
+    VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+
+    _ShellStep = _TotalShellStep / _ShellAmount;
 
     float moveFactor = pow(abs((float)index / _ShellAmount), _BaseMove.w);
     float3 posOS = input.positionOS.xyz;
@@ -59,10 +134,33 @@ void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, 
     stream.Append(output);
 }
 
-[maxvertexcount(51)]
-void geom(triangle Attributes input[3], inout TriangleStream<Varyings> stream)
+//-----------------------------------(below) For Microsoft Shader Model > 4.1-----------------------------------
+// See "Lit.hlsl" for more information.
+#if defined(_GEOM_INSTANCING)
+[instance(3)]
+[maxvertexcount(39)]
+void geom(triangle v2g input[3], inout TriangleStream<g2f> stream, uint instanceID : SV_GSInstanceID)
 {
-    [loop] for (float i = 0; i < _ShellAmount; ++i)
+    // 13 is calculated manually, because "maxvertexcount" is 39 in "Lit.hlsl", keep all passes to have the smallest (39 now).
+    // If not, DepthNormals will be incorrect and Depth Priming (DepthNormal Mode) won't work.
+    // "39 / 3 = 13", 3 means 3 vertices of a tirangle.
+    [loop] for (float i = 0 + (instanceID * 13); i < _ShellAmount; ++i)
+    {
+        [unroll] for (float j = 0; j < 3; ++j)
+        {
+            AppendShellVertexInstancing(stream, input[j], i);
+        }
+        stream.RestartStrip();
+    }
+}
+//-----------------------------------(above) For Microsoft Shader Model > 4.1-----------------------------------
+
+//-----------------------------------(below) For Microsoft Shader Model < 4.1-----------------------------------
+#else
+[maxvertexcount(39)]
+void geom(triangle v2g input[3], inout TriangleStream<g2f> stream)
+{
+    [loop] for (float i = 0; i < clamp(_ShellAmount, 1, 13); ++i)
     {
         [unroll] for (float j = 0; j < 3; ++j)
         {
@@ -71,8 +169,10 @@ void geom(triangle Attributes input[3], inout TriangleStream<Varyings> stream)
         stream.RestartStrip();
     }
 }
+#endif
+//-----------------------------------(above) For Microsoft Shader Model < 4.1-----------------------------------
 
-float4 frag(Varyings input) : SV_Target
+float4 frag(g2f input) : SV_Target
 {
     float4 furColor = SAMPLE_TEXTURE2D(_FurMap, sampler_FurMap, input.uv / _BaseMap_ST.xy * _FurScale);
     float alpha = furColor.r * (1.0 - input.layer);

--- a/Assets/Fur/Shaders/Shell/DepthNormals.hlsl
+++ b/Assets/Fur/Shaders/Shell/DepthNormals.hlsl
@@ -1,0 +1,95 @@
+#ifndef FUR_SHELL_DEPTH_NORMALS_HLSL
+#define FUR_SHELL_DEPTH_NORMALS_HLSL
+
+#include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderVariablesFunctions.hlsl"
+#include "./Param.hlsl"
+
+struct Attributes
+{
+    half4 positionOS : POSITION;
+    half3 normalOS : NORMAL;
+    half4 tangentOS : TANGENT;
+    float2 uv : TEXCOORD0;
+};
+
+struct Varyings
+{
+    float4 vertex : SV_POSITION;
+    float2 uv : TEXCOORD0;
+    //float  fogCoord : TEXCOORD1;
+    float  layer : TEXCOORD1;
+    float3 normalWS : TEXCOORD2;
+    float3 tangentWS : TEXCOORD3;
+    float3 posWS : TEXCOORD4;
+};
+
+Attributes vert(Attributes input)
+{
+    return input;
+}
+
+void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, int index)
+{
+    Varyings output = (Varyings)0;
+
+    VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
+    VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+
+    float moveFactor = pow(abs((float)index / _ShellAmount), _BaseMove.w);
+    float3 posOS = input.positionOS.xyz;
+    float3 windAngle = _Time.w * _WindFreq.xyz;
+    float3 windMove = moveFactor * _WindMove.xyz * sin(windAngle + posOS * _WindMove.w);
+    float3 move = moveFactor * _BaseMove.xyz;
+
+    float3 shellDir = SafeNormalize(normalInput.normalWS + move + windMove);
+    float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.uv / _BaseMap_ST.xy * _FurScale, 0).x;
+    float3 posWS = vertexInput.positionWS + shellDir * (_ShellStep * index * FurLength * _FurLengthIntensity);
+    float4 posCS = TransformWorldToHClip(posWS);
+
+    output.vertex = posCS;
+    output.posWS = posWS;
+    output.uv = TRANSFORM_TEX(input.uv, _BaseMap);
+    output.layer = (float)index / _ShellAmount;
+
+    output.normalWS = normalInput.normalWS;
+    output.tangentWS = normalInput.tangentWS;
+
+
+    stream.Append(output);
+}
+
+[maxvertexcount(51)]
+void geom(triangle Attributes input[3], inout TriangleStream<Varyings> stream)
+{
+    [loop] for (float i = 0; i < _ShellAmount; ++i)
+    {
+        [unroll] for (float j = 0; j < 3; ++j)
+        {
+            AppendShellVertex(stream, input[j], i);
+        }
+        stream.RestartStrip();
+    }
+}
+
+float4 frag(Varyings input) : SV_Target
+{
+    float4 furColor = SAMPLE_TEXTURE2D(_FurMap, sampler_FurMap, input.uv / _BaseMap_ST.xy * _FurScale);
+    float alpha = furColor.r * (1.0 - input.layer);
+    if (input.layer > 0.0 && alpha < _AlphaCutout) discard;
+
+    float3 viewDirWS = SafeNormalize(GetCameraPositionWS() - input.posWS);
+    half3 normalTS = UnpackNormalScale(
+        SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, input.uv / _BaseMap_ST.xy * _FurScale),
+        _NormalScale);
+    float3 bitangent = SafeNormalize(viewDirWS.y * cross(input.normalWS, input.tangentWS));
+    float3 normalWS = SafeNormalize(TransformTangentToWorld(
+        normalTS,
+        float3x3(input.tangentWS, bitangent, input.normalWS)));
+
+    // Stores World Space Normal to "_CameraNormalsTexture", no depth needed currently.
+    return float4(NormalizeNormalPerPixel(normalWS), 0.0);
+
+}
+
+#endif

--- a/Assets/Fur/Shaders/Shell/DepthNormals.hlsl
+++ b/Assets/Fur/Shaders/Shell/DepthNormals.hlsl
@@ -43,7 +43,7 @@ void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, 
     float3 move = moveFactor * _BaseMove.xyz;
 
     float3 shellDir = SafeNormalize(normalInput.normalWS + move + windMove);
-    float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.uv / _BaseMap_ST.xy * _FurScale, 0).x;
+    float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.uv / _BaseMap_ST.xy, 0).x;
     float3 posWS = vertexInput.positionWS + shellDir * (_ShellStep * index * FurLength * _FurLengthIntensity);
     float4 posCS = TransformWorldToHClip(posWS);
 

--- a/Assets/Fur/Shaders/Shell/DepthNormals.hlsl.meta
+++ b/Assets/Fur/Shaders/Shell/DepthNormals.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9cb306cee9064a94ab6fd8359189c7b4
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Fur/Shaders/Shell/FurSpecular.hlsl
+++ b/Assets/Fur/Shaders/Shell/FurSpecular.hlsl
@@ -4,29 +4,6 @@
 //-------------------------------------------------------------------------------------------------
 // Fur shading from "maajor"'s https://github.com/maajor/Marschner-Hair-Unity, licensed under MIT.
 //-------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------
-/*MIT License
-
-Copyright (c) 2019 maajor
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.*/
-//-------------------------------------------------------------------------------------------------
 
 struct SurfaceOutputFur
 // Upgrade NOTE: excluded shader from DX11, OpenGL ES 2.0 because it uses unsized arrays

--- a/Assets/Fur/Shaders/Shell/FurSpecular.hlsl
+++ b/Assets/Fur/Shaders/Shell/FurSpecular.hlsl
@@ -1,0 +1,177 @@
+#ifndef FUR_SPECULAR_HLSL
+#define FUR_SPECULAR_HLSL
+
+//-------------------------------------------------------------------------------------------------
+// Fur shading from "maajor"'s https://github.com/maajor/Marschner-Hair-Unity, licensed under MIT.
+//-------------------------------------------------------------------------------------------------
+
+struct SurfaceOutputFur
+// Upgrade NOTE: excluded shader from DX11, OpenGL ES 2.0 because it uses unsized arrays
+//#pragma exclude_renderers d3d11 gles
+{
+	half3 Albedo;
+	half MedulaScatter;
+	half MedulaAbsorb;
+	half3 Normal;//Tangent actually
+	half3 VNormal;//vertext normal
+	half3 Emission;
+	half Alpha;
+	half Roughness;
+	half Specular;
+	half Layer;
+	half Kappa;
+};
+
+inline float square(float x) {
+	return x * x;
+}
+
+float acosFast(float inX)
+{
+	float x = abs(inX);
+	float res = -0.156583f * x + (0.5 * PI);
+	res *= sqrt(1.0f - x);
+	return (inX >= 0) ? res : PI - res;
+}
+
+#define SQRT2PI 2.50663
+
+//Gaussian Distribution for M term
+inline float Hair_G(float B, float Theta)
+{
+	return exp(-0.5 * square(Theta) / (B*B)) / (SQRT2PI * B);
+}
+
+
+inline float3 SpecularFresnel(float3 F0, float vDotH) {
+	return F0 + (1.0f - F0) * pow(1 - vDotH, 5);
+}
+
+inline float3 SpecularFresnelLayer(float3 F0, float vDotH, float layer) {
+	float3 fresnel = SpecularFresnel(F0,  vDotH);
+    return (fresnel * layer) / (1 + (layer-1) * fresnel);
+}
+
+// Yan, Ling-Qi, etc, "An efficient and practical near and far field fur reflectance model."
+float3 FurBSDFYan(SurfaceOutputFur s, float3 L, float3 V, float3 N, float Shadow, float Backlit, float Area)
+{
+	float3 S = 0;
+
+	const float VoL = dot(V, L);
+	const float SinThetaL = dot(N, L);
+	const float SinThetaV = dot(N, V);
+	float cosThetaL = sqrt(max(0, 1 - SinThetaL * SinThetaL));
+	float cosThetaV = sqrt(max(0, 1 - SinThetaV * SinThetaV));
+	float CosThetaD = sqrt((1 + cosThetaL * cosThetaV + SinThetaV * SinThetaL) / 2.0);
+
+	const float3 Lp = L - SinThetaL * N;
+	const float3 Vp = V - SinThetaV * N;
+	const float CosPhi = dot(Lp, Vp) * rsqrt(dot(Lp, Lp) * dot(Vp, Vp) + 1e-4);
+	const float CosHalfPhi = sqrt(saturate(0.5 + 0.5 * CosPhi));
+
+	float n_prime = 1.19 / CosThetaD + 0.36 * CosThetaD;
+
+	float Shift = 0.0499f;
+	float Alpha[] =
+	{
+		-0.0998,//-Shift * 2,
+		0.0499f,// Shift,
+		0.1996  // Shift * 4
+	};
+	float B[] =
+	{
+		Area + square(s.Roughness),
+		Area + square(s.Roughness) / 2,
+		Area + square(s.Roughness) * 2
+	};
+
+	//float F0 = square((1 - 1.55f) / (1 + 1.55f));
+	float F0 = 0.04652;//eta=1.55f
+
+	float3 Tp;
+	float Mp, Np, Fp, a, h, f;
+	float ThetaH = SinThetaL + SinThetaV;
+	// R
+	Mp = Hair_G(B[0], ThetaH - Alpha[0]);
+	Np = 0.25 * CosHalfPhi;
+	Fp = SpecularFresnelLayer(F0, sqrt(saturate(0.5 + 0.5 * VoL)), s.Layer).x;
+	S += (Mp * Np) * (Fp * lerp(1, Backlit, saturate(-VoL)));
+
+	// TT
+	Mp = Hair_G(B[1], ThetaH - Alpha[1]);
+	a = rcp(n_prime);
+	h = CosHalfPhi * (1 + a * (0.6 - 0.8 * CosPhi));
+	f = SpecularFresnelLayer(F0, CosThetaD * sqrt(saturate(1 - h * h)), s.Layer).x;
+	Fp = square(1 - f);
+	float sinGammaTSqr = square((h * a));
+	float sm = sqrt(saturate(square(s.Kappa)-sinGammaTSqr));
+	float sc = sqrt(1 - sinGammaTSqr) - sm;
+	Tp = pow(s.Albedo, 0.5 * sc / CosThetaD) * pow(s.MedulaAbsorb*s.MedulaScatter, 0.5 * sm / CosThetaD);
+	Np = exp(-3.65 * CosPhi - 3.98);
+	S += (Mp * Np) * (Fp * Tp) * Backlit;
+
+	// TRT
+	Mp = Hair_G(B[2], ThetaH - Alpha[2]);
+	f = SpecularFresnelLayer(F0, CosThetaD * 0.5f, s.Layer).x;
+	Fp = square(1 - f) * f;
+	// assume h = sqrt(3)/2, calculate sm and sc
+	sm = sqrt(saturate(square(s.Kappa)-0.75f));
+	sc = 0.5f - sm;
+	Tp = pow(s.Albedo, sc / CosThetaD) * pow(s.MedulaAbsorb*s.MedulaScatter, sm / CosThetaD);
+	Np = exp((6.3f*CosThetaD+0.7f)*CosPhi-(5*CosThetaD+2));
+
+	S += (Mp * Np) * (Fp * Tp);
+
+	// TTs
+	// hacking approximate Cm
+	Mp = abs(cosThetaL)*0.5f;
+	// still assume h = sqrt(3)/2
+	Tp = pow(s.Albedo, (sc+1-s.Kappa)/(4*CosThetaD)) * pow(s.MedulaAbsorb, s.Kappa / (4*CosThetaD));
+	// hacking approximate pre-integrated Dtts based on Cn
+	Np = 0.05*(2*CosPhi*CosPhi - 1) + 0.16f;//0.05*std::cos(2*Phi) + 0.16f;
+
+	S += (Mp * Np) * (f * Tp);
+
+	//TRTs
+	float phi = acosFast(CosPhi);
+	// hacking approximate pre-integrated Dtrts based on Cn
+	Np = 0.05f * cos(1.5*phi+1.7) + 0.18f;
+	// still assume h = sqrt(3)/2
+	Tp = pow(s.Albedo, (3*sc+1-s.Kappa)/(4*CosThetaD)) * pow(s.MedulaAbsorb, (2*sm+s.Kappa) / (4*CosThetaD)) * pow(s.MedulaScatter, sm/(8*CosThetaD));
+	Fp = f * (1-f);
+
+	S += (Mp * Np) * (Fp * Tp);
+
+	return S;
+}
+
+float3 FurDiffuseKajiya(SurfaceOutputFur s, float3 L, float3 V, float3 N, half Shadow, float Backlit, float Area) {
+	float3 S = 0;
+	float KajiyaDiffuse = 1 - abs(dot(N, L));
+
+	float3 FakeNormal = SafeNormalize(V - N * dot(V, N));
+	N = FakeNormal;
+
+	// Hack approximation for multiple scattering.
+	float Wrap = 1;
+	float NoL = saturate((dot(N, L) + Wrap) / square(1 + Wrap));
+	float DiffuseScatter = (1 / PI) * lerp(NoL, KajiyaDiffuse, 0.33);// *s.Metallic;
+	float Luma = Luminance(s.Albedo);
+	float3 ScatterTint = pow(s.Albedo / Luma, 1 - Shadow);
+	S = sqrt(s.Albedo) * DiffuseScatter * ScatterTint;
+	return S;
+}
+
+float3 FurBxDF(SurfaceOutputFur s, float3 N, half3 V, half3 L, float Shadow, float Backlit, float Area)
+{
+	float3 S = float3(0, 0, 0);
+
+	S = FurBSDFYan(s, L, V, N, Shadow, Backlit, Area);
+	S += FurDiffuseKajiya(s, L, V, N, Shadow, Backlit, Area);
+
+	S = -min(-S, 0.0);
+
+	return S;
+}
+
+#endif

--- a/Assets/Fur/Shaders/Shell/FurSpecular.hlsl
+++ b/Assets/Fur/Shaders/Shell/FurSpecular.hlsl
@@ -4,6 +4,29 @@
 //-------------------------------------------------------------------------------------------------
 // Fur shading from "maajor"'s https://github.com/maajor/Marschner-Hair-Unity, licensed under MIT.
 //-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+/*MIT License
+
+Copyright (c) 2019 maajor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.*/
+//-------------------------------------------------------------------------------------------------
 
 struct SurfaceOutputFur
 // Upgrade NOTE: excluded shader from DX11, OpenGL ES 2.0 because it uses unsized arrays

--- a/Assets/Fur/Shaders/Shell/FurSpecular.hlsl.meta
+++ b/Assets/Fur/Shaders/Shell/FurSpecular.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4a9c4eb5427894546b064ec7b5e51258
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Fur/Shaders/Shell/Lit.hlsl
+++ b/Assets/Fur/Shaders/Shell/Lit.hlsl
@@ -126,7 +126,7 @@ float4 frag(Varyings input) : SV_Target
 #if defined(_FUR_SPECULAR)
     // Use abs(f) to avoid warning messages that f should not be negative in pow(f, e).
     SurfaceOutputFur s = (SurfaceOutputFur)0;
-    s.Albedo = abs(SAMPLE_TEXTURE2D(_BaseMap, sampler_BaseMap, furUv).rgb * _BaseColor.rgb);
+    s.Albedo = abs(SAMPLE_TEXTURE2D(_BaseMap, sampler_BaseMap, input.uv).rgb * _BaseColor.rgb);
     s.MedulaScatter = abs(_MedulaScatter);
     s.MedulaAbsorb = abs(_MedulaAbsorb);
     s.Normal = input.tangentWS;

--- a/Assets/Fur/Shaders/Shell/Lit.hlsl
+++ b/Assets/Fur/Shaders/Shell/Lit.hlsl
@@ -8,6 +8,8 @@
 #if defined(_FUR_SPECULAR)
 #include "./FurSpecular.hlsl"
 #endif
+// VR single pass instance compability:
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 
 struct Attributes
 {
@@ -19,7 +21,17 @@ struct Attributes
     UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
-struct Varyings
+struct v2g
+{
+    float4 positionOS : POSITION;
+    float3 normalOS : NORMAL;
+    float4 tangentOS : TANGENT;
+    float2 texcoord : TEXCOORD0;
+    float2 lightmapUV : TEXCOORD1;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+};
+
+struct g2f
 {
     float4 positionCS : SV_POSITION;
     float3 positionWS : TEXCOORD0;
@@ -29,19 +41,87 @@ struct Varyings
     DECLARE_LIGHTMAP_OR_SH(lightmapUV, vertexSH, 5);
     float4 fogFactorAndVertexLight : TEXCOORD6; // x: fogFactor, yzw: vertex light
     float  layer : TEXCOORD7;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+    UNITY_VERTEX_OUTPUT_STEREO
 };
 
-Attributes vert(Attributes input)
+v2g vert(Attributes input)
 {
-    return input;
+    v2g output = (v2g)0;
+    // setup the instanced id
+    UNITY_SETUP_INSTANCE_ID(input);
+    // set all values in the "v2g output" to 0.0
+    // This is the URP version of UNITY_INITIALIZE_OUTPUT()
+    ZERO_INITIALIZE(v2g, output);
+    // copy instance id in the "Attributes input" to the "v2g output"
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+
+    output.positionOS = input.positionOS;
+    output.normalOS = input.normalOS;
+    output.tangentOS = input.tangentOS;
+    output.lightmapUV = input.lightmapUV;
+    output.texcoord = input.texcoord;
+    return output;
 }
 
-void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, int index)
+void AppendShellVertex(inout TriangleStream<g2f> stream, v2g input, int index)
 {
-    Varyings output = (Varyings)0;
+    g2f output = (g2f)0;
+    UNITY_SETUP_INSTANCE_ID(input);
+    // set all values in the g2f output to 0.0
+    ZERO_INITIALIZE(g2f, output);
+
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
 
     VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
     VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+
+    float clampedShellAmount = clamp(_ShellAmount, 1, 13);
+    _ShellStep = _TotalShellStep / clampedShellAmount;
+
+    float moveFactor = pow(abs((float)index / clampedShellAmount), _BaseMove.w);
+    float3 posOS = input.positionOS.xyz;
+    float3 windAngle = _Time.w * _WindFreq.xyz;
+    float3 windMove = moveFactor * _WindMove.xyz * sin(windAngle + posOS * _WindMove.w);
+    float3 move = moveFactor * _BaseMove.xyz;
+    float3 shellDir = SafeNormalize(normalInput.normalWS + move + windMove);
+    float3 viewDirWS = GetCameraPositionWS() - vertexInput.positionWS;
+    float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.texcoord / _BaseMap_ST.xy, 0).x;
+    
+    output.positionWS = vertexInput.positionWS + shellDir * (_ShellStep * index * FurLength * _FurLengthIntensity);
+    output.positionCS = TransformWorldToHClip(output.positionWS);
+    output.uv = TRANSFORM_TEX(input.texcoord, _BaseMap);
+    output.normalWS = normalInput.normalWS;
+    output.tangentWS = normalInput.tangentWS;
+    output.layer = (float)index / clampedShellAmount;
+
+    float3 vertexLight = VertexLighting(vertexInput.positionWS, normalInput.normalWS);
+    float fogFactor = ComputeFogFactor(vertexInput.positionCS.z);
+    output.fogFactorAndVertexLight = float4(fogFactor, vertexLight);
+
+    OUTPUT_LIGHTMAP_UV(input.lightmapUV, unity_LightmapST, output.lightmapUV);
+    OUTPUT_SH(output.normalWS.xyz, output.vertexSH);
+
+
+    stream.Append(output);
+}
+
+// For geometry shader instancing, no clamp on _ShellAmount.
+void AppendShellVertexInstancing(inout TriangleStream<g2f> stream, v2g input, int index)
+{
+    g2f output = (g2f)0;
+    UNITY_SETUP_INSTANCE_ID(input);
+    // set all values in the g2f output to 0.0
+    ZERO_INITIALIZE(g2f, output);
+
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+    VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
+    VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+
+    _ShellStep = _TotalShellStep / _ShellAmount;
 
     float moveFactor = pow(abs((float)index / _ShellAmount), _BaseMove.w);
     float3 posOS = input.positionOS.xyz;
@@ -51,7 +131,7 @@ void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, 
     float3 shellDir = SafeNormalize(normalInput.normalWS + move + windMove);
     float3 viewDirWS = GetCameraPositionWS() - vertexInput.positionWS;
     float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.texcoord / _BaseMap_ST.xy, 0).x;
-    
+
     output.positionWS = vertexInput.positionWS + shellDir * (_ShellStep * index * FurLength * _FurLengthIntensity);
     output.positionCS = TransformWorldToHClip(output.positionWS);
     output.uv = TRANSFORM_TEX(input.texcoord, _BaseMap);
@@ -66,13 +146,52 @@ void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, 
     OUTPUT_LIGHTMAP_UV(input.lightmapUV, unity_LightmapST, output.lightmapUV);
     OUTPUT_SH(output.normalWS.xyz, output.vertexSH);
 
+
     stream.Append(output);
 }
 
-[maxvertexcount(42)]
-void geom(triangle Attributes input[3], inout TriangleStream<Varyings> stream)
+//-----------------------------------(below) For Microsoft Shader Model > 4.1-----------------------------------
+// "[instance(3)]" = 3+1 geometry shader instances, so we can have at most 13x4 = 52 shells
+//
+// If you need 200 shells (too much for game):
+// "200 / 13 = 15, remains 5"
+// 
+// You will need "16" instances, "15" for 195 shells, "1" for 5 remaining shells.
+// 
+// IMPORTANT: if you set [instance(30)] for 200 shells, you will waste performance because
+//            "stream.RestartStrip()" will run on 14 istances (with empty output).
+// 
+//            Please keep "n" in [instance(n)] the same for all "passes.hlsl" (Lit, Depth, DepthNormals, Shadow,...)
+//            Or something will break! (post-processing in most cases)
+// 
+// LIMIT: You can only have up to 32 instances, so (32+1)x13 = 429 shells at most.
+#if defined(_GEOM_INSTANCING)
+[instance(3)]
+[maxvertexcount(39)]
+void geom(triangle v2g input[3], inout TriangleStream<g2f> stream, uint instanceID : SV_GSInstanceID)
 {
-    [loop] for (float i = 0; i < _ShellAmount; ++i)
+    // 13 is calculated manually, because "maxvertexcount" is 39 in "Lit.hlsl", keep all passes to have the smallest (39 now).
+    // If not, DepthNormals will be incorrect and Depth Priming (DepthNormal Mode) won't work.
+    // "39 / 3 = 13", 3 means 3 vertices of a tirangle.
+    [loop] for (float i = 0 + (instanceID * 13); i < _ShellAmount; ++i)
+    {
+        [unroll] for (float j = 0; j < 3; ++j)
+        {
+            AppendShellVertexInstancing(stream, input[j], i);
+        }
+        stream.RestartStrip();
+    }
+}
+//-----------------------------------(above) For Microsoft Shader Model > 4.1-----------------------------------
+
+//-----------------------------------(below) For Microsoft Shader Model < 4.1-----------------------------------
+// For device that does not support geometry shader instancing.
+// Available since Microsoft Shader Model 4.1, it is "target 4.6" in Unity.
+#else
+[maxvertexcount(39)]
+void geom(triangle v2g input[3], inout TriangleStream<g2f> stream)
+{
+    [loop] for (float i = 0; i < clamp(_ShellAmount, 1, 13); ++i)
     {
         [unroll] for (float j = 0; j < 3; ++j)
         {
@@ -81,14 +200,17 @@ void geom(triangle Attributes input[3], inout TriangleStream<Varyings> stream)
         stream.RestartStrip();
     }
 }
+#endif
+//-----------------------------------(above) For Microsoft Shader Model < 4.1-----------------------------------
 
 inline float3 TransformHClipToWorld(float4 positionCS)
 {
     return mul(UNITY_MATRIX_I_VP, positionCS).xyz;
 }
 
-float4 frag(Varyings input) : SV_Target
+float4 frag(g2f input) : SV_Target
 {
+
     float2 furUv = input.uv / _BaseMap_ST.xy * _FurScale;
     float4 furColor = SAMPLE_TEXTURE2D(_FurMap, sampler_FurMap, furUv);
     float alpha = furColor.r * (1.0 - input.layer);
@@ -158,6 +280,8 @@ float4 frag(Varyings input) : SV_Target
 
     ApplyRimLight(color.rgb, input.positionWS, viewDirWS, normalWS);
     color.rgb += _AmbientColor;
+    // Disable "Specular Highlights" instead of clamping,
+    // to avoid reducing Bloom and Scatter strength.
     color.rgb = MixFog(color.rgb, inputData.fogCoord);
 
     return color;

--- a/Assets/Fur/Shaders/Shell/Lit.hlsl
+++ b/Assets/Fur/Shaders/Shell/Lit.hlsl
@@ -157,6 +157,7 @@ void AppendShellVertexInstancing(inout TriangleStream<g2f> stream, v2g input, in
 // "200 / 13 = 15, remains 5"
 // 
 // You will need "16" instances, "15" for 195 shells, "1" for 5 remaining shells.
+// So, use [instance(15)] to execute "15+1" instances.
 // 
 // IMPORTANT: if you set [instance(30)] for 200 shells, you will waste performance because
 //            "stream.RestartStrip()" will run on 14 istances (with empty output).

--- a/Assets/Fur/Shaders/Shell/Lit.hlsl
+++ b/Assets/Fur/Shaders/Shell/Lit.hlsl
@@ -50,7 +50,7 @@ void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, 
     float3 move = moveFactor * _BaseMove.xyz;
     float3 shellDir = SafeNormalize(normalInput.normalWS + move + windMove);
     float3 viewDirWS = GetCameraPositionWS() - vertexInput.positionWS;
-    float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.texcoord / _BaseMap_ST.xy * _FurScale, 0).x;
+    float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.texcoord / _BaseMap_ST.xy, 0).x;
     
     output.positionWS = vertexInput.positionWS + shellDir * (_ShellStep * index * FurLength * _FurLengthIntensity);
     output.positionCS = TransformWorldToHClip(output.positionWS);

--- a/Assets/Fur/Shaders/Shell/Lit.shader
+++ b/Assets/Fur/Shaders/Shell/Lit.shader
@@ -58,7 +58,7 @@ SubShader
 
     ZWrite On
     ZTest LEqual
-    Cull Off
+    Cull Back
 
     Pass
     {
@@ -68,7 +68,7 @@ SubShader
         ZWrite On
 
         HLSLPROGRAM
-        // URP §Œ•≠©`•Ô©`•…
+        // URP „ÅÆ„Ç≠„Éº„ÉØ„Éº„Éâ
         #pragma multi_compile _ _MAIN_LIGHT_SHADOWS
         #pragma multi_compile _ _MAIN_LIGHT_SHADOWS_CASCADE
         #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
@@ -82,7 +82,7 @@ SubShader
 
         #pragma multi_compile_fragment _ _FUR_SPECULAR
 
-        // Unity §Œ•≠©`•Ô©`•…
+        // Unity „ÅÆ„Ç≠„Éº„ÉØ„Éº„Éâ
         #pragma multi_compile _ DIRLIGHTMAP_COMBINED
         #pragma multi_compile _ LIGHTMAP_ON
         #pragma multi_compile_fog

--- a/Assets/Fur/Shaders/Shell/Lit.shader
+++ b/Assets/Fur/Shaders/Shell/Lit.shader
@@ -78,7 +78,7 @@ SubShader
         #pragma multi_compile _ _SHADOWS_SOFT
         #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
         #pragma multi_compile_fragment _ _LIGHT_LAYERS
-        //#pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
+        #pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
         #pragma shader_feature _ _SPECULARHIGHLIGHTS_OFF
 
         #pragma multi_compile_fragment _ _FUR_SPECULAR

--- a/Assets/Fur/Shaders/Shell/Lit.shader
+++ b/Assets/Fur/Shaders/Shell/Lit.shader
@@ -9,6 +9,8 @@ Properties
     _BaseMap("Albedo", 2D) = "white" {}
     [Gamma] _Metallic("Metallic", Range(0.0, 1.0)) = 0.5
     _Smoothness("Smoothness", Range(0.0, 1.0)) = 0.5
+    
+    [Header(Reduce Flickering)][Space]
     [ToggleOff] _SpecularHighlights("Specular Highlights", Float) = 0.0
 
     [Header(Fur)][Space]
@@ -31,9 +33,9 @@ Properties
     _RimLightPower("Rim Light Power", Range(1.0, 20.0)) = 6.0
     _RimLightIntensity("Rim Light Intensity", Range(0.0, 1.0)) = 0.5
 
-    [Header(Marschner Specular)][Space]
+    [Header(Marschner Scatter)][Space]
     [Toggle(_FUR_SPECULAR)] _FurSpecular("Enable", Float) = 0
-    _Backlit("Backlit", Range(0.0, 1.0)) = 0.5
+    _Backlit("Back Lit", Range(0.0, 1.0)) = 0.5
     _Area("Lit Area", Range(0.01, 1.0)) = 0.1
     _MedulaScatter("Fur Scatter", Range(0.01, 1.0)) = 1.0
     _MedulaAbsorb("Fur Absorb", Range(0.01, 1.0)) = 0.1
@@ -78,7 +80,6 @@ SubShader
         #pragma multi_compile_fragment _ _LIGHT_LAYERS
         //#pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
         #pragma shader_feature _ _SPECULARHIGHLIGHTS_OFF
-        #pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
 
         #pragma multi_compile_fragment _ _FUR_SPECULAR
 

--- a/Assets/Fur/Shaders/Shell/Lit.shader
+++ b/Assets/Fur/Shaders/Shell/Lit.shader
@@ -9,16 +9,19 @@ Properties
     _BaseMap("Albedo", 2D) = "white" {}
     [Gamma] _Metallic("Metallic", Range(0.0, 1.0)) = 0.5
     _Smoothness("Smoothness", Range(0.0, 1.0)) = 0.5
-    
+
     [Header(Reduce Flickering)][Space]
     [ToggleOff] _SpecularHighlights("Specular Highlights", Float) = 0.0
 
     [Header(Fur)][Space]
-    _FurMap("Fur", 2D) = "white" {}
-    [Normal] _NormalMap("Normal", 2D) = "bump" {}
+    [NoScaleOffset]_FurMap("Fur", 2D) = "white" {}
+    [NoScaleOffset][Normal] _NormalMap("Normal", 2D) = "bump" {}
     _NormalScale("Normal Scale", Range(0.0, 2.0)) = 1.0
-    [IntRange] _ShellAmount("Shell Amount", Range(1, 14)) = 14
-    _ShellStep("Shell Step", Range(0.0, 0.02)) = 0.001
+    [IntRange] _ShellAmount("Shell Amount", Range(1, 52)) = 13
+    [Header(More Shell Amount)][Space]
+    [Toggle(_GEOM_INSTANCING)] _GeomInstancing("Enable", Float) = 0
+    [HideInInspector] _ShellStep("Shell Step", Range(0.0, 0.02)) = 0.001
+    [Space][Space] _TotalShellStep("Total Shell Step", Range(0.0, 0.25)) = 0.026
     _AlphaCutout("Alpha Cutout", Range(0.0, 1.0)) = 0.2
     _FurScale("Fur Scale", Range(0.0, 10.0)) = 1.0
     _Occlusion("Occlusion", Range(0.0, 1.0)) = 0.5
@@ -35,7 +38,7 @@ Properties
 
     [Header(Marschner Scatter)][Space]
     [Toggle(_FUR_SPECULAR)] _FurSpecular("Enable", Float) = 0
-    _Backlit("Back Lit", Range(0.0, 1.0)) = 0.5
+    _Backlit("Backlit", Range(0.0, 1.0)) = 0.5
     _Area("Lit Area", Range(0.01, 1.0)) = 0.1
     _MedulaScatter("Fur Scatter", Range(0.01, 1.0)) = 1.0
     _MedulaAbsorb("Fur Absorb", Range(0.01, 1.0)) = 0.1
@@ -43,6 +46,7 @@ Properties
 
     [Header(Shadow)][Space]
     _ShadowExtraBias("Shadow Extra Bias", Range(-1.0, 1.0)) = 0.0
+    [Toggle(_NO_FUR_SHADOW)] _NoFurShadow("Mesh Shadow Only", Float) = 0
     
 }
 
@@ -70,30 +74,40 @@ SubShader
         ZWrite On
 
         HLSLPROGRAM
-        // URP „ÅÆ„Ç≠„Éº„ÉØ„Éº„Éâ
+        // URP §Œ•≠©`•Ô©`•…
+#if (UNITY_VERSION >= 202111)
+        #pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
+        #pragma multi_compile_fragment _ _LIGHT_LAYERS
+#else
         #pragma multi_compile _ _MAIN_LIGHT_SHADOWS
         #pragma multi_compile _ _MAIN_LIGHT_SHADOWS_CASCADE
+#endif
         #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
         #pragma multi_compile _ _ADDITIONAL_LIGHT_SHADOWS
         #pragma multi_compile _ _SHADOWS_SOFT
         #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
-        #pragma multi_compile_fragment _ _LIGHT_LAYERS
         #pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
         #pragma shader_feature _ _SPECULARHIGHLIGHTS_OFF
+        //#pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
 
         #pragma multi_compile_fragment _ _FUR_SPECULAR
+        #pragma multi_compile _ _GEOM_INSTANCING
 
-        // Unity „ÅÆ„Ç≠„Éº„ÉØ„Éº„Éâ
+        // Unity §Œ•≠©`•Ô©`•…
         #pragma multi_compile _ DIRLIGHTMAP_COMBINED
         #pragma multi_compile _ LIGHTMAP_ON
         #pragma multi_compile_fog
+        #pragma multi_compile_instancing
+        #pragma multi_compile _ DOTS_INSTANCING_ON
 
         #pragma prefer_hlslcc gles
         #pragma exclude_renderers d3d11_9x
-        #pragma target 2.0
+        // if "_GEOM_INSTANCING", then Microsoft ShaderModel 4.1 (geometry shader instancing support)
+        // It is "target 4.6" in Unity. (Tested on OpenGL 4.1, instancing not supported on OpenGL 4.0)
+        #pragma target 4.6 _GEOM_INSTANCING
         #pragma vertex vert
         #pragma require geometry
-        #pragma geometry geom 
+        #pragma geometry geom
         #pragma fragment frag
         #include "./Lit.hlsl"
         ENDHLSL
@@ -108,10 +122,121 @@ SubShader
         ColorMask 0
 
         HLSLPROGRAM
+        #pragma multi_compile _ _GEOM_INSTANCING
+
         #pragma exclude_renderers gles
         #pragma vertex vert
         #pragma require geometry
-        #pragma geometry geom 
+        #pragma geometry geom
+        #pragma fragment frag
+        #pragma target 4.6 _GEOM_INSTANCING
+        #include "./Depth.hlsl"
+        ENDHLSL
+    }
+
+    Pass
+    {
+        Name "DepthNormals"
+        Tags { "LightMode" = "DepthNormals" }
+
+        ZWrite On
+
+        HLSLPROGRAM
+        #pragma multi_compile _ _GEOM_INSTANCING
+
+        #pragma exclude_renderers gles
+        #pragma vertex vert
+        #pragma require geometry
+        #pragma geometry geom
+        #pragma fragment frag
+        #pragma target 4.6 _GEOM_INSTANCING
+        #include "./DepthNormals.hlsl"
+        ENDHLSL
+    }
+
+    Pass
+    {
+        Name "ShadowCaster"
+        Tags { "LightMode" = "ShadowCaster" }
+
+        ZWrite On
+        ZTest LEqual
+        ColorMask 0
+
+        HLSLPROGRAM
+        #pragma multi_compile _ _GEOM_INSTANCING
+        #pragma multi_compile _ _NO_FUR_SHADOW
+
+        #pragma exclude_renderers gles
+        #pragma vertex vert
+        #pragma require geometry
+        #pragma geometry geom
+        #pragma fragment frag
+        #pragma target 4.6 _GEOM_INSTANCING
+        #include "./Shadow.hlsl"
+        ENDHLSL
+    }
+
+//---------------------------For Microsoft Shader Model < 4.1---------------------------------------------
+//-----------------------Geometry Shader Instancing not supported.----------------------------------------
+    Pass
+    {
+        Name "ForwardLit"
+        Tags { "LightMode" = "UniversalForward" }
+
+        ZWrite On
+
+        HLSLPROGRAM
+        // URP §Œ•≠©`•Ô©`•…
+#if (UNITY_VERSION >= 202111)
+        #pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
+        #pragma multi_compile_fragment _ _LIGHT_LAYERS
+#else
+        #pragma multi_compile _ _MAIN_LIGHT_SHADOWS
+        #pragma multi_compile _ _MAIN_LIGHT_SHADOWS_CASCADE
+#endif
+        #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
+        #pragma multi_compile _ _ADDITIONAL_LIGHT_SHADOWS
+        #pragma multi_compile _ _SHADOWS_SOFT
+        #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
+        #pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
+        #pragma shader_feature _ _SPECULARHIGHLIGHTS_OFF
+        //#pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+
+        #pragma multi_compile_fragment _ _FUR_SPECULAR
+
+        // Unity §Œ•≠©`•Ô©`•…
+        #pragma multi_compile _ DIRLIGHTMAP_COMBINED
+        #pragma multi_compile _ LIGHTMAP_ON
+        #pragma multi_compile_fog
+        #pragma multi_compile_instancing
+        #pragma multi_compile _ DOTS_INSTANCING_ON
+
+        #pragma prefer_hlslcc gles
+        #pragma exclude_renderers d3d11_9x
+        #pragma vertex vert
+        #pragma require geometry
+        #pragma geometry geom
+        #pragma fragment frag
+        #include "./Lit.hlsl"
+        ENDHLSL
+    }
+
+    Pass
+    {
+        Name "DepthOnly"
+        Tags { "LightMode" = "DepthOnly" }
+
+        ZWrite On
+        ColorMask 0
+
+        HLSLPROGRAM
+        #pragma multi_compile _ _GEOM_INSTANCING
+
+        #pragma exclude_renderers gles
+        #pragma vertex vert
+        #pragma require geometry
+        #pragma geometry geom
         #pragma fragment frag
         #include "./Depth.hlsl"
         ENDHLSL
@@ -125,10 +250,12 @@ SubShader
         ZWrite On
 
         HLSLPROGRAM
+        #pragma multi_compile _ _GEOM_INSTANCING
+
         #pragma exclude_renderers gles
         #pragma vertex vert
         #pragma require geometry
-        #pragma geometry geom 
+        #pragma geometry geom
         #pragma fragment frag
         #include "./DepthNormals.hlsl"
         ENDHLSL
@@ -144,10 +271,12 @@ SubShader
         ColorMask 0
 
         HLSLPROGRAM
+        #pragma multi_compile _ _NO_FUR_SHADOW
+
         #pragma exclude_renderers gles
         #pragma vertex vert
         #pragma require geometry
-        #pragma geometry geom 
+        #pragma geometry geom
         #pragma fragment frag
         #include "./Shadow.hlsl"
         ENDHLSL

--- a/Assets/Fur/Shaders/Shell/Lit.shader
+++ b/Assets/Fur/Shaders/Shell/Lit.shader
@@ -74,7 +74,7 @@ SubShader
         ZWrite On
 
         HLSLPROGRAM
-        // URP §Œ•≠©`•Ô©`•…
+        // URP „ÅÆ„Ç≠„Éº„ÉØ„Éº„Éâ
 #if (UNITY_VERSION >= 202111)
         #pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
         #pragma multi_compile_fragment _ _LIGHT_LAYERS
@@ -93,7 +93,7 @@ SubShader
         #pragma multi_compile_fragment _ _FUR_SPECULAR
         #pragma multi_compile _ _GEOM_INSTANCING
 
-        // Unity §Œ•≠©`•Ô©`•…
+        // Unity „ÅÆ„Ç≠„Éº„ÉØ„Éº„Éâ
         #pragma multi_compile _ DIRLIGHTMAP_COMBINED
         #pragma multi_compile _ LIGHTMAP_ON
         #pragma multi_compile_fog
@@ -187,7 +187,7 @@ SubShader
         ZWrite On
 
         HLSLPROGRAM
-        // URP §Œ•≠©`•Ô©`•…
+        // URP „ÅÆ„Ç≠„Éº„ÉØ„Éº„Éâ
 #if (UNITY_VERSION >= 202111)
         #pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
         #pragma multi_compile_fragment _ _LIGHT_LAYERS
@@ -205,7 +205,7 @@ SubShader
 
         #pragma multi_compile_fragment _ _FUR_SPECULAR
 
-        // Unity §Œ•≠©`•Ô©`•…
+        // Unity „ÅÆ„Ç≠„Éº„ÉØ„Éº„Éâ
         #pragma multi_compile _ DIRLIGHTMAP_COMBINED
         #pragma multi_compile _ LIGHTMAP_ON
         #pragma multi_compile_fog

--- a/Assets/Fur/Shaders/Shell/Param.hlsl
+++ b/Assets/Fur/Shaders/Shell/Param.hlsl
@@ -21,4 +21,13 @@ SAMPLER(sampler_NormalMap);
 float4 _NormalMap_ST;
 float _NormalScale;
 
+TEXTURE2D(_FurLengthMap);
+SAMPLER(sampler_FurLengthMap);
+float _FurLengthIntensity;
+
+float _Backlit;
+float _Area;
+float _MedulaScatter;
+float _MedulaAbsorb;
+float _Kappa;
 #endif

--- a/Assets/Fur/Shaders/Shell/Param.hlsl
+++ b/Assets/Fur/Shaders/Shell/Param.hlsl
@@ -25,6 +25,8 @@ TEXTURE2D(_FurLengthMap);
 SAMPLER(sampler_FurLengthMap);
 float _FurLengthIntensity;
 
+float _TotalShellStep;
+
 float _Backlit;
 float _Area;
 float _MedulaScatter;

--- a/Assets/Fur/Shaders/Shell/Shadow.hlsl
+++ b/Assets/Fur/Shaders/Shell/Shadow.hlsl
@@ -43,7 +43,7 @@ void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, 
     float3 move = moveFactor * _BaseMove.xyz;
 
     float3 shellDir = normalize(normalInput.normalWS + move + windMove);
-    float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.uv / _BaseMap_ST.xy * _FurScale, 0).x;
+    float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.uv / _BaseMap_ST.xy, 0).x;
     float3 posWS = vertexInput.positionWS + shellDir * (_ShellStep * index * FurLength * _FurLengthIntensity);
     //float4 posCS = TransformWorldToHClip(posWS);
     float4 posCS = GetShadowPositionHClip(posWS, normalInput.normalWS);

--- a/Assets/Fur/Shaders/Shell/Shadow.hlsl
+++ b/Assets/Fur/Shaders/Shell/Shadow.hlsl
@@ -3,10 +3,12 @@
 
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/CommonMaterial.hlsl"
-// Declare "_BaseMap_ST" for line 46.
+// Declare "_BaseMap_ST" for line 76.
 #include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitInput.hlsl"
 #include "./Param.hlsl"
 #include "../Common/Common.hlsl"
+// For VR single pass instance compability:
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 
 struct Attributes
 {
@@ -14,29 +16,63 @@ struct Attributes
     float3 normalOS : NORMAL;
     float4 tangentOS : TANGENT;
     float2 uv : TEXCOORD0;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
-struct Varyings
+struct v2g
+{
+    float4 positionOS : POSITION;
+    float3 normalOS : NORMAL;
+    float4 tangentOS : TANGENT;
+    float2 uv : TEXCOORD0;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+};
+
+struct g2f
 {
     float4 vertex : SV_POSITION;
     float2 uv : TEXCOORD0;
     float  fogCoord : TEXCOORD1;
     float  layer : TEXCOORD2;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+    UNITY_VERTEX_OUTPUT_STEREO
 };
 
-Attributes vert(Attributes input)
+v2g vert(Attributes input)
 {
-    return input;
+    v2g output = (v2g)0;
+    // setup the instanced id
+    UNITY_SETUP_INSTANCE_ID(input);
+    // set all values in the "v2g output" to 0.0
+    // This is the URP version of UNITY_INITIALIZE_OUTPUT()
+    ZERO_INITIALIZE(v2g, output);
+    // copy instance id in the "Attributes input" to the "v2g output"
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+
+    output.positionOS = input.positionOS;
+    output.normalOS = input.normalOS;
+    output.tangentOS = input.tangentOS;
+    output.uv = input.uv;
+    return output;
 }
 
-void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, int index)
+void AppendShellVertex(inout TriangleStream<g2f> stream, v2g input, int index)
 {
-    Varyings output = (Varyings)0;
+    g2f output = (g2f)0;
+    UNITY_SETUP_INSTANCE_ID(input);
+    // set all values in the g2f output to 0.0
+    ZERO_INITIALIZE(g2f, output);
+
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
 
     VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
     VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
 
-    float moveFactor = pow(abs((float)index / _ShellAmount), _BaseMove.w);
+    float clampedShellAmount = clamp(_ShellAmount, 1, 13);
+    _ShellStep = _TotalShellStep / clampedShellAmount;
+
+    float moveFactor = pow(abs((float)index / clamp(_ShellAmount, 1, 13)), _BaseMove.w);
     float3 posOS = input.positionOS.xyz;
     float3 windAngle = _Time.w * _WindFreq.xyz;
     float3 windMove = moveFactor * _WindMove.xyz * sin(windAngle + posOS * _WindMove.w);
@@ -51,15 +87,84 @@ void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, 
     output.vertex = posCS;
     output.uv = TRANSFORM_TEX(input.uv, _FurMap);
     output.fogCoord = ComputeFogFactor(posCS.z);
+    output.layer = (float)index / clamp(_ShellAmount, 1, 13);
+
+    stream.Append(output);
+}
+
+// For geometry shader instancing, no clamp on _ShellAmount.
+void AppendShellVertexInstancing(inout TriangleStream<g2f> stream, v2g input, int index)
+{
+    g2f output = (g2f)0;
+    UNITY_SETUP_INSTANCE_ID(input);
+    // set all values in the g2f output to 0.0
+    ZERO_INITIALIZE(g2f, output);
+
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+    VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
+    VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+
+    _ShellStep = _TotalShellStep / _ShellAmount;
+
+    float moveFactor = pow(abs((float)index / _ShellAmount), _BaseMove.w);
+    float3 posOS = input.positionOS.xyz;
+    float3 windAngle = _Time.w * _WindFreq.xyz;
+    float3 windMove = moveFactor * _WindMove.xyz * sin(windAngle + posOS * _WindMove.w);
+    float3 move = moveFactor * _BaseMove.xyz;
+
+    float3 shellDir = normalize(normalInput.normalWS + move + windMove);
+    float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.uv / _BaseMap_ST.xy, 0).x;
+    float3 posWS = vertexInput.positionWS + shellDir * (_ShellStep * index * FurLength * _FurLengthIntensity);
+    //float4 posCS = TransformWorldToHClip(posWS);
+    float4 posCS = GetShadowPositionHClip(posWS, normalInput.normalWS);
+
+    output.vertex = posCS;
+    output.uv = TRANSFORM_TEX(input.uv, _FurMap);
+    output.fogCoord = ComputeFogFactor(posCS.z);
     output.layer = (float)index / _ShellAmount;
 
     stream.Append(output);
 }
 
-[maxvertexcount(128)]
-void geom(triangle Attributes input[3], inout TriangleStream<Varyings> stream)
+//-----------------------------------(below) For Microsoft Shader Model > 4.1-----------------------------------
+// See "Lit.hlsl" for more information.
+#if defined(_GEOM_INSTANCING)
+[instance(3)]
+[maxvertexcount(39)]
+void geom(triangle v2g input[3], inout TriangleStream<g2f> stream, uint instanceID : SV_GSInstanceID)
 {
-    [loop] for (float i = 0; i < _ShellAmount; ++i)
+#if defined(_NO_FUR_SHADOW)
+    float loopTimes = 1;
+#else
+    float loopTimes = _ShellAmount;
+#endif
+    // 13 is calculated manually, because "maxvertexcount" is 39 in "Lit.hlsl", keep all passes to have the smallest (39 now).
+    // If not, DepthNormals will be incorrect and Depth Priming (DepthNormal Mode) won't work.
+    // "39 / 3 = 13", 3 means 3 vertices of a tirangle.
+    [loop] for (float i = 0 + (instanceID * 13); i < loopTimes; ++i)
+    {
+        [unroll] for (float j = 0; j < 3; ++j)
+        {
+            AppendShellVertexInstancing(stream, input[j], i);
+        }
+        stream.RestartStrip();
+    }
+}
+//-----------------------------------(above) For Microsoft Shader Model > 4.1-----------------------------------
+
+//-----------------------------------(below) For Microsoft Shader Model < 4.1-----------------------------------
+#else
+[maxvertexcount(39)]
+void geom(triangle v2g input[3], inout TriangleStream<g2f> stream)
+{
+#if defined(_NO_FUR_SHADOW)
+    float loopTimes = 1;
+#else
+    float loopTimes = clamp(_ShellAmount, 1, 13);
+#endif
+    [loop] for (float i = 0; i < loopTimes; ++i)
     {
         [unroll] for (float j = 0; j < 3; ++j)
         {
@@ -68,9 +173,11 @@ void geom(triangle Attributes input[3], inout TriangleStream<Varyings> stream)
         stream.RestartStrip();
     }
 }
+#endif
+//-----------------------------------(above) For Microsoft Shader Model < 4.1-----------------------------------
 
 void frag(
-    Varyings input, 
+    g2f input, 
     out float4 outColor : SV_Target, 
     out float outDepth : SV_Depth)
 {

--- a/Assets/Fur/Shaders/Shell/Shadow.hlsl
+++ b/Assets/Fur/Shaders/Shell/Shadow.hlsl
@@ -3,6 +3,8 @@
 
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/CommonMaterial.hlsl"
+// Declare "_BaseMap_ST" for line 46.
+#include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitInput.hlsl"
 #include "./Param.hlsl"
 #include "../Common/Common.hlsl"
 
@@ -41,7 +43,8 @@ void AppendShellVertex(inout TriangleStream<Varyings> stream, Attributes input, 
     float3 move = moveFactor * _BaseMove.xyz;
 
     float3 shellDir = normalize(normalInput.normalWS + move + windMove);
-    float3 posWS = vertexInput.positionWS + shellDir * (_ShellStep * index);
+    float FurLength = SAMPLE_TEXTURE2D_LOD(_FurLengthMap, sampler_FurLengthMap, input.uv / _BaseMap_ST.xy * _FurScale, 0).x;
+    float3 posWS = vertexInput.positionWS + shellDir * (_ShellStep * index * FurLength * _FurLengthIntensity);
     //float4 posCS = TransformWorldToHClip(posWS);
     float4 posCS = GetShadowPositionHClip(posWS, normalInput.normalWS);
     


### PR DESCRIPTION
Commit into Shell (Lit) because it is the most performant one among three.

### Changes:

### 1. Add "DepthNormals" Pass (For forward renderer, stores normal only).
- "_CameraNormalsTexture"
![Fur-DepthNormals](https://user-images.githubusercontent.com/62869447/165296241-ccd5fbea-07fe-430d-8ad6-165e3bca43ee.jpg)

- Now SSAO (Depth Normal mode) works. (Should enable "After Opaque" in URP 12)
- URP 12 Depth Priming (Depth pre-pass) works.

### 2. Adding specular scattering. (No effect on front face)

- from "maajor"'s https://github.com/maajor/Marschner-Hair-Unity, licensed under [MIT](https://github.com/maajor/Marschner-Hair-Unity/blob/master/LICENSE).
![Fur-Scatter](https://user-images.githubusercontent.com/62869447/165296536-15da6c13-ddcc-4d3a-9dc4-ee7531b8a3ac.jpg)
![Fur-Rim](https://user-images.githubusercontent.com/62869447/165297028-29c81499-5507-4c61-9691-cb56a0d86784.jpg)


### 3. Controlling fur length using one texture (Red channel).
- Should be **black and white**, using red channel if it's color texture.
![Fur-Length](https://user-images.githubusercontent.com/62869447/165298075-2bee9d64-e292-48bf-bf52-3946a022b9ce.jpg)


### 4. Fixed issues when using Depth Priming on URP 12. 
- Depth Priming avoids rendering pixels that are occluded by front pixels [probably] which **improves performance**
![Fur-DepthPriming](https://user-images.githubusercontent.com/62869447/165298704-1f055d04-fddc-4e63-ae92-1823856323a3.jpg)

### 5. Fixed MainLight Shadow issue on URP 12. (Shell Lit only)
- #4 

### 6. Add XR single pass instance support for both Shell Lit and Unlit.
- #8 
- Adjusted from cdibbs's PR that:
- avoiding *.cginc files, because URP does not suggest using them.
![Fur-VRSinglePassInstance](https://user-images.githubusercontent.com/62869447/165839155-eecce56d-3549-425c-a0eb-405a31065ba4.jpg)

### 7. Increase maximum Shell Amount (13 to 52). (Optional)
- Using geometry shader instancing, so it requires ["#pragma target 4.6"](https://docs.unity3d.com/Manual/SL-ShaderCompileTargets.html). (Equivalent to OpenGL 4.1)
- If the device does not support "#pragma target 4.6", it will fall back to 13 shells maximum. (No error should occur)
- **The `Shell Step` is now being replaced by `Total Shell Step`.**
- **so that no matter how many shells are using, fall back fur appearance should not change too much.**
- You may control it more from the comments in Shell's "Lit.hlsl".
![Fur-50Shells](https://user-images.githubusercontent.com/62869447/165841261-d342f476-b7bf-438b-b8eb-694d23e4d1f0.jpg)
![Fur-13Shells](https://user-images.githubusercontent.com/62869447/165841390-86f5cbcc-beae-4e74-b161-aebbb6c34620.jpg)
- The performance should still be better than the other two method. (Also please try Depth Priming)

- If your fur is "toooo long", you will meet Camera Frustum Culling issue at the edges of view, you can try increasing [mesh bounds](https://docs.unity3d.com/ScriptReference/Mesh-bounds.html) and that should solve the problem. (Other two fur methods should also meet this issue if "toooo long")


### 8. Add disable fur shadow option. (Mesh Shadow Only)
 - Sometimes, the correct shapes of shadow can be less important (hard to notice? it depends...).
![Fur-MeshShadowOnly](https://user-images.githubusercontent.com/62869447/165842630-e76c7ba5-f5bc-4326-ad0e-32c270d1df86.jpg)


Quick tested on Unity 2020.3.23, no visible problem [probably]:
![Tested on Unity2020](https://user-images.githubusercontent.com/62869447/165295578-56364376-2051-40c5-b6f7-5380176cc97e.jpg)
