### PR TITLE
fix SSAO calculation

### DIFF
--- a/Assets/Fur/Shaders/Shell/Lit.hlsl
+++ b/Assets/Fur/Shaders/Shell/Lit.hlsl
@@ -116,6 +116,7 @@ float4 frag(Varyings input) : SV_Target
     inputData.fogCoord = input.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
     inputData.bakedGI = SAMPLE_GI(input.lightmapUV, input.vertexSH, normalWS);
+    inputData.normalizedScreenSpaceUV = GetNormalizedScreenSpaceUV(input.positionCS);
 
     float4 color = UniversalFragmentPBR(inputData, surfaceData);
 


### PR DESCRIPTION
Due to not using "InitializeInputData(...)" for generating InputData, we need to calculate ScreenSpaceUV manually.

SSAO in URP 10 and above requires:
- DepthOnly Pass ✅
- DepthNormals Pass ✅
- SSAO Keyword ✅
- ScreenSpaceUV in InputData (if using URP's lighting function)

[URP 10 upgrade guide](https://docs.unity3d.com/Packages/com.unity.render-pipelines.universal@10.8/manual/upgrade-guide-10-0-x.html):
<img width="536" alt="image" src="https://user-images.githubusercontent.com/62869447/171988311-4c1c6236-9a9e-4aaf-bd81-8a490aa84550.png">
