### PR TITLE
Fix shell shadows being offset

### DIFF
--- a/Assets/Fur/Shaders/Shell/Depth.hlsl
+++ b/Assets/Fur/Shaders/Shell/Depth.hlsl
@@ -63,16 +63,13 @@ void geom(triangle Attributes input[3], inout TriangleStream<Varyings> stream)
     }
 }
 
-void frag(
-    Varyings input, 
-    out float4 outColor : SV_Target, 
-    out float outDepth : SV_Depth)
+half4 frag(Varyings input) : SV_Target
 {
     float4 furColor = SAMPLE_TEXTURE2D(_FurMap, sampler_FurMap, input.uv / _BaseMap_ST.xy * _FurScale);
     float alpha = furColor.r * (1.0 - input.layer);
     if (input.layer > 0.0 && alpha < _AlphaCutout) discard;
 
-    outColor = outDepth = input.vertex.z / input.vertex.w;
+    return 0;
 }
 
 #endif

--- a/Assets/Fur/Shaders/Shell/Shadow.hlsl
+++ b/Assets/Fur/Shaders/Shell/Shadow.hlsl
@@ -66,16 +66,13 @@ void geom(triangle Attributes input[3], inout TriangleStream<Varyings> stream)
     }
 }
 
-void frag(
-    Varyings input, 
-    out float4 outColor : SV_Target, 
-    out float outDepth : SV_Depth)
+half4 frag(Varyings input) : SV_Target
 {
     float4 furColor = SAMPLE_TEXTURE2D(_FurMap, sampler_FurMap, input.uv * _FurScale);
     float alpha = furColor.r * (1.0 - input.layer);
     if (input.layer > 0.0 && alpha < _AlphaCutout) discard;
 
-    outColor = outDepth = input.vertex.z / input.vertex.w;
+    return 0;
 }
 
 #endif


### PR DESCRIPTION
Shell shadows get clipped near the camera or are too far offset in depth with custom depth being set. I've changed the way they're calculated to be more consistent with the way that the fragment function works in URP. 
https://github.com/needle-mirror/com.unity.render-pipelines.universal/blob/a158b7a53654edcf071beab1016cdcbc8fe8aff1/Shaders/ShadowCasterPass.hlsl#L59